### PR TITLE
feat: add workflow that will run gh-pages deployment on master branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,43 @@
+name: CI/CD
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Build
+      run: CI='' npm run build
+
+    - name: Deploy
+      run: |
+        git config --global user.name $user_name
+        git config --global user.email $user_email
+        git remote set-url origin https://${github_token}@github.com/${repository}
+        npm run deploy
+      env:
+        user_name: 'github-actions[bot]'
+        user_email: 'github-actions[bot]@users.donoreply.github.com'
+        github_token: ${{ secrets.ACTIONS_DEPLOY_ACCESS_TOKEN }}
+        repository: ${{ github.repository }} 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "learn",
   "version": "0.1.0",
   "private": true,
-  "homepage": "http://yifeili98.github.io/fhda-about",
+  "homepage": "https://fhda.github.io/Frontend",
   "dependencies": {
     "@testing-library/jest-dom": "^5.12.0",
     "@testing-library/react": "^11.2.6",
@@ -22,7 +22,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "predeploy": "npm run build",
+    "predeploy": "CI='' npm run build",
     "deploy": "gh-pages -d build"
   },
   "eslintConfig": {


### PR DESCRIPTION
I just finished the ```ci_dev``` branch which will automatically put the newest PR/commit of the master branch into a workflow that will generate from the react project to a static webpage that can be displayed here [https://fhda.github.io/Frontend/](https://fhda.github.io/Frontend/).  This static webpage is just for demonstration purposes so everyone could have an idea of how the frontend progresses.

The files for the static webpage will be in the ```gh-pages``` branch and this process is done by using ```gh-pages``` npm module in ```.github\workflows\main.yml ```
.
```ci_dev``` branch will be deleted after this workflow PR is merged into master.