### PR TITLE
Add loading visualization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12797,6 +12797,11 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "react-loading": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npm.taobao.org/react-loading/download/react-loading-2.0.3.tgz",
+      "integrity": "sha1-6BOPsMPkZ05IGzIIAqxwSK4U/7k="
+    },
     "react-overlays": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-bootstrap": "^1.6.0",
     "react-browser-router": "^2.1.2",
     "react-dom": "^17.0.2",
+    "react-loading": "^2.0.3",
     "react-reveal": "^1.2.2",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",

--- a/src/assets/css/courseItem.css
+++ b/src/assets/css/courseItem.css
@@ -1,26 +1,20 @@
 .courses-items {
   list-style: none;
-  margin: 0;
-  margin-top: 10px;
-  padding-left: 20px;
-  padding-top: 20px;
-  padding-right: 20px;
-  max-height: 80vh;
+  display: grid;
+  place-items: center;
+  padding: 20px;
   overflow: auto;
-  border: 4px;
   border: 1px solid;
   width: fit-content;
-  min-height: 80vh;
-  position: relative;
-  align-items: center;
+  height: 80vh;
 }
 
 .course-item:hover {
   background-color: #f8f8f8;
 }
 
-.loading {
+/* .loading {
   left: 45%;
   top: 45%;
   position: absolute;
-} /* 50%? */
+} 50%? */

--- a/src/assets/css/courseItem.css
+++ b/src/assets/css/courseItem.css
@@ -12,8 +12,15 @@
   width: fit-content;
   min-height: 80vh;
   position: relative;
+  align-items: center;
 }
 
 .course-item:hover {
   background-color: #f8f8f8;
 }
+
+.loading {
+  left: 45%;
+  top: 45%;
+  position: absolute;
+} /* 50%? */

--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -1,0 +1,17 @@
+import React from "react";
+import ReactLoading from "react-loading";
+import "../assets/css/courseItem.css";
+
+const Loading = (props) => {
+  return (
+    <ReactLoading
+      type={props.type}
+      color={props.color}
+      height={props.height}
+      width={props.width}
+      className="loading"
+    />
+  );
+};
+
+export default Loading;

--- a/src/pages/catalog/Catalog.js
+++ b/src/pages/catalog/Catalog.js
@@ -9,7 +9,7 @@ import Loading from "../../components/Loading";
 
 function Catalog() {
   const [courses, setCourses] = useState([]);
-  const [filtedCourses, setFiltedCourses] = useState([]);
+  const [filteredCourses, setFilteredCourses] = useState([]);
   const [specificCourse, setSpecificCourse] = useState({});
   const [filterInfo, setFilterInfo] = useState();
 
@@ -46,10 +46,11 @@ function Catalog() {
   const coursesFilter = (input) => {
     const keyWord = input.trim().replace(" ", "").replace(/[\\]/g, "");
     const filteredClasses = fuzzyQuery(courses, keyWord);
-    setFiltedCourses(filteredClasses);
+    setFilteredCourses(filteredClasses);
   };
 
   useEffect(async () => {
+    localStorage.clear();
     //do https requrest
     const allCourses = [];
     axios
@@ -73,7 +74,7 @@ function Catalog() {
           allCourses.push(course);
         }
         setCourses(allCourses);
-        setFiltedCourses(allCourses);
+        setFilteredCourses(allCourses);
         setFilterInfo({ campus: "DeAnza", quarter: "Summer", year: "2021" });
         const cache_list = [
           { campus: "DeAnza", quarter: "Summer", year: "2021" },
@@ -89,7 +90,7 @@ function Catalog() {
   }, []);
 
   const clearCardsHandler = () => {
-    setFiltedCourses([]);
+    setFilteredCourses([]);
   };
 
   const filterHandler = (filter_key, filter_value) => {
@@ -106,11 +107,18 @@ function Catalog() {
         };
         allCourses.push(course);
       }
+      var cache_list = JSON.parse(localStorage.getItem("cache_list"));
+      if (cache_list.length > 8) {
+        localStorage.removeItem(cache_list[0]);
+        localStorage.removeItem(cache_list[0].concat("cards"));
+        cache_list = cache_list.shift();
+      }
+
       localStorage.setItem(
         JSON.stringify(filter_key),
         JSON.stringify(filter_value.data)
       );
-      var cache_list = JSON.parse(localStorage.getItem("cache_list"));
+      //var cache_list = JSON.parse(localStorage.getItem("cache_list"));
       cache_list.push(filter_key);
       localStorage.setItem("cache_list", JSON.stringify(cache_list));
       localStorage.setItem(
@@ -124,7 +132,7 @@ function Catalog() {
     }
     setFilterInfo(filter_key);
     setCourses(allCourses);
-    setFiltedCourses(allCourses);
+    setFilteredCourses(allCourses);
     setSpecificCourse({});
   }; // can be refactored
 
@@ -140,7 +148,7 @@ function Catalog() {
   };
 
   const courseCardsContent =
-    filtedCourses.length === 0 ? (
+    filteredCourses.length === 0 || filteredCourses === undefined ? (
       <Loading
         type="spinningBubbles"
         color="#8f0505"
@@ -149,7 +157,7 @@ function Catalog() {
         className={"loading"}
       />
     ) : (
-      filtedCourses.map((course) => {
+      filteredCourses.map((course) => {
         return (
           <CourseItem
             key={course.key}

--- a/src/pages/catalog/Catalog.js
+++ b/src/pages/catalog/Catalog.js
@@ -1,16 +1,17 @@
-import React, { useState, useCallback } from "react";
-import Header from "../../components/Header";
+import React, { useState, useCallback, useEffect } from "react";
 import CoursesWrapper from "../../components/CoursesWrapper";
 import CourseItem from "../../components/CourseItem";
 import axios from "axios";
-import { Container, Row, Col } from "react-bootstrap";
+import { Container, Row } from "react-bootstrap";
 import Filter from "./Filter";
 import CatalogDescription from "../../components/CatalogDescription";
+import Loading from "../../components/Loading";
 
 function Catalog() {
   const [courses, setCourses] = useState([]);
   const [filtedCourses, setFiltedCourses] = useState([]);
   const [specificCourse, setSpecificCourse] = useState({});
+  const [filterInfo, setFilterInfo] = useState();
 
   String.prototype.splice = function (idx, rem, str) {
     return this.slice(0, idx) + str + this.slice(idx + Math.abs(rem));
@@ -26,7 +27,7 @@ function Catalog() {
     var reverseIndex = keyWord.length;
     //Finds case for ++, change it to \+\+
     while (reverseIndex > 0) {
-      if (keyWord[reverseIndex] != "+") {
+      if (keyWord[reverseIndex] !== "+") {
         reverseIndex--;
       } else {
         keyWord = keyWord.splice(reverseIndex, 0, "\\");
@@ -48,6 +49,49 @@ function Catalog() {
     setFiltedCourses(filteredClasses);
   };
 
+  useEffect(async () => {
+    //do https requrest
+    const allCourses = [];
+    axios
+      .get(
+        "https://fhda-api-test.azurewebsites.net/course_list?year=2021&quarter=Summer"
+      )
+      .then((res) => {
+        localStorage.setItem(
+          //This string can be obtained from API later, so I hardcode it here
+          '{"campus":"DeAnza","quarter":"Summer","year":"2021"}',
+          JSON.stringify(res.data)
+        );
+        for (const key in res.data) {
+          const courseObj = res.data[key];
+          let course = {
+            key: parseInt(key),
+            courseName: courseObj.courseTitle,
+            courseNum: courseObj.courseNum,
+            unit: +courseObj.numCredit,
+          };
+          allCourses.push(course);
+        }
+        setCourses(allCourses);
+        setFiltedCourses(allCourses);
+        setFilterInfo({ campus: "DeAnza", quarter: "Summer", year: "2021" });
+        const cache_list = [
+          { campus: "DeAnza", quarter: "Summer", year: "2021" },
+        ];
+        localStorage.setItem("cache_list", JSON.stringify(cache_list));
+        localStorage.setItem(
+          '{"campus":"DeAnza","quarter":"Summer","year":"2021"}'.concat(
+            "cards"
+          ),
+          JSON.stringify(allCourses)
+        );
+      });
+  }, []);
+
+  const clearCardsHandler = () => {
+    setFiltedCourses([]);
+  };
+
   const filterHandler = (filter_key, filter_value) => {
     var allCourses = [];
     const cache = JSON.parse(localStorage.getItem(JSON.stringify(filter_key)));
@@ -62,15 +106,23 @@ function Catalog() {
         };
         allCourses.push(course);
       }
-      localStorage.setItem(JSON.stringify(filter_key), JSON.stringify(allCourses));
+      localStorage.setItem(
+        JSON.stringify(filter_key),
+        JSON.stringify(filter_value.data)
+      );
       var cache_list = JSON.parse(localStorage.getItem("cache_list"));
       cache_list.push(filter_key);
       localStorage.setItem("cache_list", JSON.stringify(cache_list));
+      localStorage.setItem(
+        JSON.stringify(filter_key).concat("cards"),
+        JSON.stringify(allCourses)
+      );
     } else {
-
-      allCourses = JSON.parse(localStorage.getItem(JSON.stringify(filter_key)));
+      allCourses = JSON.parse(
+        localStorage.getItem(JSON.stringify(filter_key).concat("cards"))
+      );
     }
-    
+    setFilterInfo(filter_key);
     setCourses(allCourses);
     setFiltedCourses(allCourses);
     setSpecificCourse({});
@@ -81,10 +133,35 @@ function Catalog() {
   };
 
   const clickCourseItemHandler = (key) => {
-    let courseString = localStorage.getItem(key);
-    let course = JSON.parse(courseString);
-    setSpecificCourse(course);
+    const allCourses = JSON.parse(
+      localStorage.getItem(JSON.stringify(filterInfo))
+    );
+    setSpecificCourse(allCourses[parseInt(key)]);
   };
+
+  const courseCardsContent =
+    filtedCourses.length === 0 ? (
+      <Loading
+        type="spinningBubbles"
+        color="#8f0505"
+        height="15%"
+        width="15%"
+        className={"loading"}
+      />
+    ) : (
+      filtedCourses.map((course) => {
+        return (
+          <CourseItem
+            key={course.key}
+            uid={course.key}
+            courseName={course.courseName}
+            courseNum={course.courseNum}
+            unit={course.unit}
+            handlerClick={clickCourseItemHandler}
+          />
+        );
+      })
+    );
 
   return (
     <React.Fragment>
@@ -94,22 +171,10 @@ function Catalog() {
             <Filter
               filterHandler={filterHandler}
               searchCourseHandler={searchCourseHandler}
+              clearCardsHandler={clearCardsHandler}
             />
           </CoursesWrapper>
-          <CoursesWrapper>
-            {filtedCourses.map((course) => {
-              return (
-                <CourseItem
-                  key={course.key}
-                  uid={course.key}
-                  courseName={course.courseName}
-                  courseNum={course.courseNum}
-                  unit={course.unit}
-                  handlerClick={clickCourseItemHandler}
-                />
-              );
-            })}
-          </CoursesWrapper>
+          <CoursesWrapper>{courseCardsContent}</CoursesWrapper>
           <CoursesWrapper>
             {Object.keys(specificCourse).length !== 0 && (
               <CatalogDescription course={specificCourse} />

--- a/src/pages/catalog/Filter.js
+++ b/src/pages/catalog/Filter.js
@@ -22,6 +22,7 @@ class Filter extends React.Component {
   }
 
   handleSelect(event) {
+    this.props.clearCardsHandler();
     var event = event.target.id;
     const selectKey = event.substring(0, event.indexOf(":"));
     const selectValue = event.substring(event.indexOf(":") + 1);
@@ -29,39 +30,42 @@ class Filter extends React.Component {
       {
         [`${selectKey}`]: selectValue,
       },
-      function() {
+      function () {
         var cache_list = localStorage.getItem("cache_list");
         if (cache_list) {
-          cache_list = JSON.parse(cache_list)
+          cache_list = JSON.parse(cache_list);
           if (cache_list.length > 8) {
             localStorage.removeItem(cache_list[0]);
             cache_list = cache_list.shift();
           }
         } else {
-          cache_list = []
-          localStorage.setItem("cache_list", JSON.stringify(cache_list))
+          cache_list = [];
+          localStorage.setItem("cache_list", JSON.stringify(cache_list));
         }
-        const cache = JSON.parse(localStorage.getItem(JSON.stringify(this.state)));
+        const cache = JSON.parse(
+          localStorage.getItem(JSON.stringify(this.state))
+        );
         if (cache) {
           this.props.filterHandler(this.state, cache);
         } else {
           axios
-              .get("https://fhda-api-test.azurewebsites.net/course_list", {
-                params: {
-                  year: this.state.year,
-                  quarter: this.state.quarter,
-                },
-              })
-              .then(
-                function (response) {
-                  //Perform action based on response
-                  this.props.filterHandler(this.state, response);
-                }.bind(this)
-              )
-              .catch(function (error) {
-                console.log(error);
-                //Perform action based on error
-              });
+            .get("https://fhda-api-test.azurewebsites.net/course_list", {
+              params: {
+                year: this.state.year,
+                quarter: this.state.quarter,
+              },
+            })
+            .then(
+              function (response) {
+                //Perform action based on response
+                console.log(response);
+                this.props.filterHandler(this.state, response);
+              }.bind(this)
+            )
+            .catch(function (error) {
+              console.log(error);
+              //Perform action based on error
+            });
         }
       }
     );
@@ -80,11 +84,10 @@ class Filter extends React.Component {
               <h5>Campus: </h5>
             </Col>
             <Col>
-              <DropdownButton
-                as={ButtonGroup}
-                title={this.state.campus}
-              >
-                <Dropdown.Item onClick={this.handleSelect} id="campus:DeAnza">DeAnza</Dropdown.Item>
+              <DropdownButton as={ButtonGroup} title={this.state.campus}>
+                <Dropdown.Item onClick={this.handleSelect} id="campus:DeAnza">
+                  DeAnza
+                </Dropdown.Item>
                 <Dropdown.Item onClick={this.handleSelect} id="campus:Foothill">
                   Foothill (Coming Soon)
                 </Dropdown.Item>
@@ -96,10 +99,7 @@ class Filter extends React.Component {
               <h5>Year: </h5>
             </Col>
             <Col>
-              <DropdownButton
-                as={ButtonGroup}
-                title={this.state.year}
-              >
+              <DropdownButton as={ButtonGroup} title={this.state.year}>
                 <Dropdown.Item onClick={this.handleSelect} id="year:2021">
                   2021 (Usable)
                 </Dropdown.Item>
@@ -114,14 +114,19 @@ class Filter extends React.Component {
               <h5>Quarter: </h5>
             </Col>
             <Col>
-              <DropdownButton
-                as={ButtonGroup}
-                title={this.state.quarter}
-              >
-                <Dropdown.Item onClick={this.handleSelect} id="quarter:Fall">Fall</Dropdown.Item>
-                <Dropdown.Item onClick={this.handleSelect} id="quarter:Winter">Winter</Dropdown.Item>
-                <Dropdown.Item onClick={this.handleSelect} id="quarter:Spring">Spring</Dropdown.Item>
-                <Dropdown.Item onClick={this.handleSelect} id="quarter:Summer">Summer</Dropdown.Item>
+              <DropdownButton as={ButtonGroup} title={this.state.quarter}>
+                <Dropdown.Item onClick={this.handleSelect} id="quarter:Fall">
+                  Fall
+                </Dropdown.Item>
+                <Dropdown.Item onClick={this.handleSelect} id="quarter:Winter">
+                  Winter
+                </Dropdown.Item>
+                <Dropdown.Item onClick={this.handleSelect} id="quarter:Spring">
+                  Spring
+                </Dropdown.Item>
+                <Dropdown.Item onClick={this.handleSelect} id="quarter:Summer">
+                  Summer
+                </Dropdown.Item>
               </DropdownButton>
             </Col>
           </Row>

--- a/src/pages/catalog/Filter.js
+++ b/src/pages/catalog/Filter.js
@@ -58,7 +58,7 @@ class Filter extends React.Component {
             .then(
               function (response) {
                 //Perform action based on response
-                console.log(response);
+                //console.log(response);
                 this.props.filterHandler(this.state, response);
               }.bind(this)
             )

--- a/src/pages/home/Home.js
+++ b/src/pages/home/Home.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import '../../assets/css/home.css';
+import { Link } from "react-router-dom";
 import districtLogo from '../../assets/pic/logo_district.png';
 
 export default function Home() {
@@ -24,7 +25,7 @@ export default function Home() {
                         skasdkasldasdasdamsdlmas;dmas;dmas;ldm;asmdsa/ 
                         askdaksd;asmda;sdm .asdlkasndasd;sa 
                     </p>
-                    <a className="searchbutton" href="./catalog">Catalog</a>
+                    <Link className="searchbutton" to="/catalog">Catalog</Link>
                 </div>
             </div>
             


### PR DESCRIPTION
## Changes
- [X] Added visualization for loading the course lists
- [X] Fixed catalog link at home page

## Issues
- [ ] Currently the loading visual will stay there when we are typing non-existing course name into the search box
- [ ] Getting course detail will fail for courses that having a crn starts with 0

This PR will not be merged until the 2 issues above are resolved, starting PR here fore gh-page auto-deployment