### PR TITLE
Add login feature (using Okta API)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "web-vitals": "^1.1.2"
   },
   "scripts": {
-    "start": "set PORT=8080 && react-scripts start",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@testing-library/jest-dom": "^5.12.0",
     "@testing-library/react": "^11.2.6",
     "@testing-library/user-event": "^12.8.3",
-    "@okta/okta-signin-widget": "^5.7.3"
+    "@okta/okta-signin-widget": "^5.7.3",
     "axios": "^0.21.1",
     "bootstrap": "^5.0.0",
     "react": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
   "dependencies": {
     "@okta/okta-auth-js": "^5.1.1",
     "@okta/okta-react": "^6.0.0",
+    "@okta/okta-signin-widget": "^5.7.3",
     "@testing-library/jest-dom": "^5.12.0",
     "@testing-library/react": "^11.2.6",
     "@testing-library/user-event": "^12.8.3",
+    "@okta/okta-signin-widget": "^5.7.3"
     "axios": "^0.21.1",
     "bootstrap": "^5.0.0",
     "react": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "learn",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://fhda.github.io/Frontend/",
+  "homepage": ".",
   "dependencies": {
     "@okta/okta-auth-js": "^5.1.1",
     "@okta/okta-react": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "homepage": "https://fhda.github.io/Frontend/",
   "dependencies": {
+    "@okta/okta-auth-js": "^5.1.1",
+    "@okta/okta-react": "^6.0.0",
     "@testing-library/jest-dom": "^5.12.0",
     "@testing-library/react": "^11.2.6",
     "@testing-library/user-event": "^12.8.3",
@@ -19,10 +21,11 @@
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
+    "semantic-ui-react": "^2.0.3",
     "web-vitals": "^1.1.2"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "set PORT=8080 && react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/src/App.js
+++ b/src/App.js
@@ -3,30 +3,45 @@ import Home from "./pages/home/Home";
 import Catalog from "./pages/catalog/Catalog";
 import Story from "./pages/story/Story";
 import About from "./pages/about/About";
-import { Route, Link } from "react-router-dom";
+import FHDANavbar from "./pages/navbar/FHDANavbar";
+import { Route, useHistory, Switch } from "react-router-dom";
 import "./assets/css/App.css";
-import { Nav, Navbar } from "react-bootstrap";
-import da_logo from "./assets/pic/fhdalogo.jpg";
+import { OktaAuth, toRelativeUrl } from '@okta/okta-auth-js';
+import { Security, LoginCallback } from '@okta/okta-react';
+
+
+const CLIENT_ID = "0oa13dfryq3ffhUKb5d7"
+const ISSUER = "https://dev-19217834.okta.com/oauth2/default"
+const config = {
+  clientId: CLIENT_ID,
+  issuer: ISSUER,
+  redirectUri: 'http://localhost:8080/login/callback',
+  scopes: ['openid', 'profile', 'email'],
+  pkce: true
+};
+const oktaAuth = new OktaAuth(config);
 
 export default function App() {
-  return (
-    <div className="App">
-      <Navbar bg="red" variant="dark" className="navbar">
-        <Link className="navbar-brand" to="/">
-          <img className="navbar-img" src={da_logo} alt="" /> FHDATime
-        </Link>
-        <Nav className="mr-auto">
-          <Link className="nav-link" to="/">Home</Link>
-          <Link className="nav-link" to="/catalog">Catalog</Link>
-          <Link className="nav-link" to="/story">Story</Link>
-          <Link className="nav-link" to="/about">About</Link>
-        </Nav>
-      </Navbar>
 
-      <Route exact path="/" render={ (routerProps) => < Home routerProps={routerProps} />} />
-      <Route exact path="/catalog" render={ (routerProps) => < Catalog routerProps={routerProps} />} />
-      <Route exact path="/story" render={ (routerProps) => < Story routerProps={routerProps} />} />
-      <Route exact path="/about" render={ (routerProps) => < About routerProps={routerProps} />} />
+  const [corsErrorModalOpen, setCorsErrorModalOpen] = React.useState(false);
+  const history = useHistory();
+  const restoreOriginalUri = async (_oktaAuth, originalUri) => {
+    history.replace(toRelativeUrl(originalUri || '/', window.location.origin));
+  };
+
+  return (
+    <div className="app">
+      <Security oktaAuth={oktaAuth} restoreOriginalUri={restoreOriginalUri}>
+        <FHDANavbar {...{ setCorsErrorModalOpen }} />
+      
+        <Switch>
+          <Route exact path="/" render={(routerProps) => < Home routerProps={routerProps} />} />
+          <Route exact path="/catalog" render={(routerProps) => < Catalog routerProps={routerProps} />} />
+          <Route exact path="/story" render={(routerProps) => < Story routerProps={routerProps} />} />
+          <Route exact path="/about" render={(routerProps) => < About routerProps={routerProps} />} />
+          <Route path="/login/callback" render={(routerProps) => < LoginCallback routerProps={routerProps} />} />
+        </Switch>
+      </Security>
     </div>
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -17,7 +17,7 @@ const ISSUER = "https://dev-19217834.okta.com/oauth2/default"
 const config = {
   clientId: CLIENT_ID,
   issuer: ISSUER,
-  redirectUri: window.origin+'/login/callback',
+  redirectUri: window.origin,
   scopes: ['openid', 'profile', 'email'],
   pkce: true
 };

--- a/src/App.js
+++ b/src/App.js
@@ -4,10 +4,12 @@ import Catalog from "./pages/catalog/Catalog";
 import Story from "./pages/story/Story";
 import About from "./pages/about/About";
 import FHDANavbar from "./pages/navbar/FHDANavbar";
+import Login from "./pages/login/Login";
 import { Route, useHistory, Switch } from "react-router-dom";
 import "./assets/css/App.css";
 import { OktaAuth, toRelativeUrl } from '@okta/okta-auth-js';
 import { Security, LoginCallback } from '@okta/okta-react';
+var OktaSignIn = require('@okta/okta-signin-widget');
 
 
 const CLIENT_ID = "0oa13dfryq3ffhUKb5d7"
@@ -28,6 +30,16 @@ export default function App() {
   const restoreOriginalUri = async (_oktaAuth, originalUri) => {
     history.replace(toRelativeUrl(originalUri || '/', window.location.origin));
   };
+  const oktaSignInConfig = {
+    baseUrl: 'https://dev-19217834.okta.com',
+    clientId: oktaAuth.options.clientId,
+    issuer: oktaAuth.options.issuer,
+    redirectUri: oktaAuth.options.redirectUri,
+    authClient: oktaAuth,
+    features: {
+       registration: true // REQUIRED
+    }
+  }
 
   return (
     <div className="app">
@@ -39,7 +51,7 @@ export default function App() {
           <Route exact path="/catalog" render={(routerProps) => < Catalog routerProps={routerProps} />} />
           <Route exact path="/story" render={(routerProps) => < Story routerProps={routerProps} />} />
           <Route exact path="/about" render={(routerProps) => < About routerProps={routerProps} />} />
-          <Route path="/login/callback" render={(routerProps) => < LoginCallback routerProps={routerProps} />} />
+          <Route path='/login' render={() => <Login config={oktaSignInConfig} />} />
         </Switch>
       </Security>
     </div>

--- a/src/App.js
+++ b/src/App.js
@@ -17,7 +17,7 @@ const ISSUER = "https://dev-19217834.okta.com/oauth2/default"
 const config = {
   clientId: CLIENT_ID,
   issuer: ISSUER,
-  redirectUri: 'http://localhost:3000/login/callback',
+  redirectUri: window.origin+'/login/callback',
   scopes: ['openid', 'profile', 'email'],
   pkce: true
 };

--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ import config from './config';
 const oktaAuth = new OktaAuth(config.oktaConfig);
 
 export default function App() {
-  console.log(config.oktaSignInConfig)
+  console.log(oktaAuth)
   const [corsErrorModalOpen, setCorsErrorModalOpen] = React.useState(false);
   const history = useHistory();
   const restoreOriginalUri = async (_oktaAuth, originalUri) => {

--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,7 @@ const ISSUER = "https://dev-19217834.okta.com/oauth2/default"
 const config = {
   clientId: CLIENT_ID,
   issuer: ISSUER,
-  redirectUri: 'http://localhost:8080/login/callback',
+  redirectUri: 'http://localhost:3000/login/callback',
   scopes: ['openid', 'profile', 'email'],
   pkce: true
 };

--- a/src/App.js
+++ b/src/App.js
@@ -35,7 +35,6 @@ export default function App() {
     clientId: oktaAuth.options.clientId,
     issuer: oktaAuth.options.issuer,
     redirectUri: oktaAuth.options.redirectUri,
-    authClient: oktaAuth,
     features: {
        registration: true // REQUIRED
     }

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,5 @@
 import React from "react";
+import "./assets/css/App.css";
 import Home from "./pages/home/Home";
 import Catalog from "./pages/catalog/Catalog";
 import Story from "./pages/story/Story";
@@ -6,39 +7,20 @@ import About from "./pages/about/About";
 import FHDANavbar from "./pages/navbar/FHDANavbar";
 import Login from "./pages/login/Login";
 import { Route, useHistory, Switch } from "react-router-dom";
-import "./assets/css/App.css";
 import { OktaAuth, toRelativeUrl } from '@okta/okta-auth-js';
-import { Security, LoginCallback } from '@okta/okta-react';
-var OktaSignIn = require('@okta/okta-signin-widget');
+import { Security } from '@okta/okta-react';
+import config from './config';
 
-
-const CLIENT_ID = "0oa13dfryq3ffhUKb5d7"
-const ISSUER = "https://dev-19217834.okta.com/oauth2/default"
-const config = {
-  clientId: CLIENT_ID,
-  issuer: ISSUER,
-  redirectUri: window.origin,
-  scopes: ['openid', 'profile', 'email'],
-  pkce: true
-};
-const oktaAuth = new OktaAuth(config);
+const oktaAuth = new OktaAuth(config.oktaConfig);
 
 export default function App() {
-
+  console.log(config.oktaSignInConfig)
   const [corsErrorModalOpen, setCorsErrorModalOpen] = React.useState(false);
   const history = useHistory();
   const restoreOriginalUri = async (_oktaAuth, originalUri) => {
     history.replace(toRelativeUrl(originalUri || '/', window.location.origin));
   };
-  const oktaSignInConfig = {
-    baseUrl: 'https://dev-19217834.okta.com',
-    clientId: oktaAuth.options.clientId,
-    issuer: oktaAuth.options.issuer,
-    redirectUri: oktaAuth.options.redirectUri,
-    features: {
-       registration: true // REQUIRED
-    }
-  }
+  
 
   return (
     <div className="app">
@@ -50,7 +32,7 @@ export default function App() {
           <Route exact path="/catalog" render={(routerProps) => < Catalog routerProps={routerProps} />} />
           <Route exact path="/story" render={(routerProps) => < Story routerProps={routerProps} />} />
           <Route exact path="/about" render={(routerProps) => < About routerProps={routerProps} />} />
-          <Route path='/login' render={() => <Login config={oktaSignInConfig} />} />
+          <Route path='/login' render={() => <Login config={config.oktaSignInConfig} />} />
         </Switch>
       </Security>
     </div>

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,21 @@
+const CLIENT_ID = "0oa13dfryq3ffhUKb5d7"
+const ISSUER = "https://dev-19217834.okta.com/oauth2/default"
+const REDIRECT_URI = window.origin;
+export default {
+    oktaConfig: {
+        clientId: CLIENT_ID,
+        issuer: ISSUER,
+        redirectUri: window.origin,
+        scopes: ['openid', 'profile', 'email'],
+        pkce: true
+  },
+    oktaSignInConfig: {
+        baseUrl: 'https://dev-19217834.okta.com',
+        clientId: CLIENT_ID,
+        issuer: ISSUER,
+        redirectUri: REDIRECT_URI,
+        features: {
+           registration: true // REQUIRED
+        }
+  },
+};

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './assets/css/index.css';
 import App from './App';
-import {HashRouter} from 'react-router-dom'
+import { BrowserRouter as Router } from 'react-router-dom';
 
 ReactDOM.render(
-  <HashRouter>
-    <App />
-  </HashRouter>,
+  <Router>
+    <App />,
+  </Router>,
   document.getElementById('root')
 );

--- a/src/pages/login/Login.js
+++ b/src/pages/login/Login.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Redirect } from 'react-router-dom';
+import OktaSignInWidget from './OktaSignInWidget';
+import { useOktaAuth } from '@okta/okta-react';
+
+const Login = ({ config }) => {
+  const { oktaAuth, authState } = useOktaAuth();
+
+  const onSuccess = (tokens) => {
+    oktaAuth.handleLoginRedirect(tokens);
+  };
+
+  const onError = (err) => {
+    console.log('error logging in', err);
+  };
+
+  if (!authState) return null;
+
+  return authState.isAuthenticated ?
+    <Redirect to={{ pathname: '/' }}/> :
+    <OktaSignInWidget
+      config={config}
+      onSuccess={onSuccess}
+      onError={onError}/>;
+};
+export default Login;

--- a/src/pages/login/Login.js
+++ b/src/pages/login/Login.js
@@ -9,10 +9,6 @@ const Login = ({ config }) => {
   const { oktaAuth, authState } = useOktaAuth();
 
   const onSuccess = (tokens) => {
-    const originalUri = oktaAuth.getOriginalUri();
-    if (originalUri === DEFAULT_ORIGINAL_URI) {
-      this.oktaAuth.setOriginalUri('/');
-    }
     oktaAuth.handleLoginRedirect(tokens);
   };
 

--- a/src/pages/login/Login.js
+++ b/src/pages/login/Login.js
@@ -3,10 +3,16 @@ import { Redirect } from 'react-router-dom';
 import OktaSignInWidget from './OktaSignInWidget';
 import { useOktaAuth } from '@okta/okta-react';
 
+const DEFAULT_ORIGINAL_URI = window.location.origin;
+
 const Login = ({ config }) => {
   const { oktaAuth, authState } = useOktaAuth();
 
   const onSuccess = (tokens) => {
+    const originalUri = oktaAuth.getOriginalUri();
+    if (originalUri === DEFAULT_ORIGINAL_URI) {
+      this.oktaAuth.setOriginalUri('/');
+    }
     oktaAuth.handleLoginRedirect(tokens);
   };
 

--- a/src/pages/login/OktaSignInWidget.js
+++ b/src/pages/login/OktaSignInWidget.js
@@ -1,0 +1,22 @@
+import React, { useEffect, useRef } from 'react';
+import OktaSignIn from '@okta/okta-signin-widget';
+import '@okta/okta-signin-widget/dist/css/okta-sign-in.min.css';
+
+const OktaSignInWidget = ({ config, onSuccess, onError }) => {
+  const widgetRef = useRef();
+  useEffect(() => {
+    if (!widgetRef.current)
+      return false;
+    
+    const widget = new OktaSignIn(config);
+
+    widget.showSignInToGetTokens({
+      el: widgetRef.current,
+    }).then(onSuccess).catch(onError);
+
+    return () => widget.remove();
+  }, [config, onSuccess, onError]);
+
+  return (<div ref={widgetRef} />);
+};
+export default OktaSignInWidget;

--- a/src/pages/login/OktaSignInWidget.js
+++ b/src/pages/login/OktaSignInWidget.js
@@ -9,11 +9,9 @@ const OktaSignInWidget = ({ config, onSuccess, onError }) => {
       return false;
     
     const widget = new OktaSignIn(config);
-
     widget.showSignInToGetTokens({
       el: widgetRef.current,
     }).then(onSuccess).catch(onError);
-
     return () => widget.remove();
   }, [config, onSuccess, onError]);
 

--- a/src/pages/navbar/FHDANavbar.js
+++ b/src/pages/navbar/FHDANavbar.js
@@ -4,15 +4,11 @@ import { Nav, Navbar } from "react-bootstrap";
 import { useOktaAuth } from '@okta/okta-react'
 import da_logo from "../../assets/pic/fhdalogo.jpg";
 
-
-
 const FHDANavbar = ({ setCorsErrorModalOpen }) => {
   console.log(useOktaAuth())
   const { authState, oktaAuth } = useOktaAuth();
   
   const isCorsError = (err) => (err.name === 'AuthApiError' && !err.errorCode && err.xhr.message === 'Failed to fetch');
-
-  const login = () => oktaAuth.signInWithRedirect();
   const logout = async () => {
     try {
       await oktaAuth.signOut();
@@ -44,7 +40,7 @@ const FHDANavbar = ({ setCorsErrorModalOpen }) => {
             <Link className="nav-link" onClick={logout} to='/'>Logout</Link>
           )}
           {!authState.isPending && !authState.isAuthenticated && (
-            <Link className="nav-link" onClick={login} to='/login/callback'>Login</Link>
+            <Link className="nav-link" to='/login'>Login</Link>
           )}
           
         </Nav>

--- a/src/pages/navbar/FHDANavbar.js
+++ b/src/pages/navbar/FHDANavbar.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Link } from "react-router-dom";
+import { Nav, Navbar } from "react-bootstrap";
+import { useOktaAuth } from '@okta/okta-react'
+import da_logo from "../../assets/pic/fhdalogo.jpg";
+
+
+
+const FHDANavbar = ({ setCorsErrorModalOpen }) => {
+  console.log(useOktaAuth())
+  const { authState, oktaAuth } = useOktaAuth();
+  
+  const isCorsError = (err) => (err.name === 'AuthApiError' && !err.errorCode && err.xhr.message === 'Failed to fetch');
+
+  const login = () => oktaAuth.signInWithRedirect();
+  const logout = async () => {
+    try {
+      await oktaAuth.signOut();
+    } catch (err) {
+      if (isCorsError(err)) {
+        setCorsErrorModalOpen(true);
+      } else {
+        throw err;
+      }
+    }
+  };
+
+  if (!authState) {
+    return null;
+  }
+
+  return (
+    <div>
+      <Navbar bg="red" variant="dark" className="navbar">
+        <Link className="navbar-brand" to="/">
+          <img className="navbar-img" src={da_logo} alt="" /> FHDATime
+        </Link>
+        <Nav className="mr-auto">
+          <Link className="nav-link" to="/">Home</Link>
+          <Link className="nav-link" to="/catalog">Catalog</Link>
+          <Link className="nav-link" to="/story">Story</Link>
+          <Link className="nav-link" to="/about">About</Link>
+          {authState.isAuthenticated && (
+            <Link className="nav-link" onClick={logout} to='/'>Logout</Link>
+          )}
+          {!authState.isPending && !authState.isAuthenticated && (
+            <Link className="nav-link" onClick={login} to='/login/callback'>Login</Link>
+          )}
+          
+        </Nav>
+      </Navbar>
+    </div>
+  );
+};
+export default FHDANavbar;

--- a/src/pages/navbar/FHDANavbar.js
+++ b/src/pages/navbar/FHDANavbar.js
@@ -5,7 +5,6 @@ import { useOktaAuth } from '@okta/okta-react'
 import da_logo from "../../assets/pic/fhdalogo.jpg";
 
 const FHDANavbar = ({ setCorsErrorModalOpen }) => {
-  console.log(useOktaAuth())
   const { authState, oktaAuth } = useOktaAuth();
   
   const isCorsError = (err) => (err.name === 'AuthApiError' && !err.errorCode && err.xhr.message === 'Failed to fetch');


### PR DESCRIPTION
## Changes
- [X] Change `homepage` in `package.json` to `.` for Netlify deployment. We may lose gh-page because Netlify has a conflict with gh-page on `homepage` format
- [X] Change HashRouter to BrowserRouter for Okta Security dependency
- [X] Add Login/Register and Logout feature and add customozied, embedded okta sign-in widget (we can customize register fields, sign-in widget logo in the future)

## Update
- [X] Moved config related constants to `config.js`
- [X] Fixed a bug that caused first-time sign in to get stuck at sign-in loading state


## Demo:
https://hardcore-hamilton-08603c.netlify.app/