### PR TITLE
refactor: remove example story articles, link with DB

### DIFF
--- a/src/pages/story/StoryList.js
+++ b/src/pages/story/StoryList.js
@@ -1,116 +1,176 @@
 import React from 'react';
+import axios from 'axios'
 import {
   Card, 
   ListGroup, 
   ListGroupItem, 
   Dropdown,
-  Button
+  Button,
+  Row,
+  Col
   } from 'react-bootstrap';
 import { Link } from "react-router-dom";
+import { useOktaAuth, withOktaAuth } from '@okta/okta-react';
 import '../../assets/css/StoryList.css'
 
-const example_articles = [
-  {
-    article_id: 100,
-    user_account_id: 1,
-    article_content: "123123123",
-    article_title: "EXAMPLE1",
-    like_count: 20,
-    view_count: 50,
-    click_count: 50,
-    post_time: new Date().toISOString(),
-    last_update_time: new Date().toISOString(),
-    school_from: "DeAnza",
-    school_to: "NYU",
-    major: "Chinese",
-    graduate_year: 2021,
-    degree_type: "本科",
-    is_spam: false,
-    is_approval: true
-  },
-  {
-    article_id: 101,
-    user_account_id: 3,
-    article_content: "blablablablablabla",
-    article_title: "EXAMPLE2",
-    like_count: 60,
-    view_count: 150,
-    click_count: 150,
-    post_time: new Date().toISOString(),
-    last_update_time: new Date().toISOString(),
-    school_from: "Foothill",
-    school_to: "UCB",
-    major: "Rocket Science",
-    graduate_year: 2021,
-    degree_type: "本科",
-    is_spam: false,
-    is_approval: true
-  },
-  {
-    article_id: 102,
-    user_account_id: 2,
-    article_content: "testtesttesttesttesttest",
-    article_title: "EXAMPLE3",
-    like_count: 26,
-    view_count: 150,
-    click_count: 650,
-    post_time: new Date().toISOString(),
-    last_update_time: new Date().toISOString(),
-    school_from: "DeAnza",
-    school_to: "UCLA",
-    major: "MATH",
-    graduate_year: 2020,
-    degree_type: "本科",
-    is_spam: false,
-    is_approval: true
-  }
-]
-var demo_filter = {1: [0,1], 2: [1,2], 3: [0,1,2]}
-class StoryList extends React.Component {
+function AuthListener() {
+  const { authState } = useOktaAuth();
+  return authState
+}
+
+export default withOktaAuth( class StoryList extends React.Component {
   constructor(props) {
     super(props);
 
     this.state = {
-      renderList: []
+      renderList: [],
+      colNum: 3         //number of columns a row could contain cards
     };
     this.updateRenderList = this.updateRenderList.bind(this);
+    this.state.test = ''
+    
+    var preRenderList = []
+    axios.get("http://127.0.0.1:5000/story", 
+      {headers: { Authorization: `Bearer ${this.props.authState.accessToken.accessToken}` }})
+      .then(
+        function (response) {
+          preRenderList = response.data
+          var mappingList = []
+          var i = 0
+          //Generate mapping list for later article card mapping
+          while (i < preRenderList.length) {
+            var innerList = []
+            for (var j = 0; j < 3; j++) {
+              if (i+j < preRenderList.length) {
+                innerList.push(preRenderList[i+j])
+              }
+            }
+            mappingList.push(innerList)
+            i += 3
+          }
+          var tempList = (
+            <div>
+              {
+                mappingList.map( function(innerList, rowNum) {
+                  return (
+                    <Row key={rowNum}>
+                      {
+                        innerList.map( function(article, colNum) {
+                          return (
+                            <Col key={colNum}>
+                              <Card className="storyCard">
+                                <Card.Body>
+                                  <Card.Title>{article.article_title} ({article.article_id})</Card.Title>
+                                  <Card.Text>
+                                    {article.article_content}
+                                  </Card.Text>
+                                </Card.Body>
+                                <ListGroup className="list-group-flush">
+                                  <ListGroupItem>like: {article.like_count} | view: {article.view_count}</ListGroupItem>
+                                  <ListGroupItem>From: {article.school_from.name} | To: {article.school_to.name}</ListGroupItem>
+                                  <ListGroupItem>Major: {article.major.name}</ListGroupItem>
+                                </ListGroup>
+                                <Card.Body>
+                                  <Card.Link href="#">Enter</Card.Link>
+                                  <Card.Link href="#">Report</Card.Link>
+                                </Card.Body>
+                              </Card>
+                            </Col>
+                          )
+                        })
+                      }
+                    </Row>
+                  )
+                })
+              }
+            </div>
+          )
+          this.state.renderList = tempList
+          this.forceUpdate()
+        }.bind(this)
+      ).catch(function (error) {
+        console.log(error);
+      });
+
   }
 
   updateRenderList(event) {
-    var tempList = []
-    if (Number.isInteger(event)) {
-      var filter_key = event
+    var url = ''
+    if (event == 'all' || event.target.id == 'all') {
+      url = "http://127.0.0.1:5000/story"
     } else {
-      var filter_key = parseInt(event.target.id)
+      url = "http://127.0.0.1:5000/story?user_id="+event.target.id
     }
-    for (var i of demo_filter[filter_key]) {
-      tempList.push(
-        <Card className="storyCard">
-          <Card.Body>
-            <Card.Title>{example_articles[i].article_title}</Card.Title>
-            <Card.Text>
-              {example_articles[i].article_content}
-            </Card.Text>
-          </Card.Body>
-          <ListGroup className="list-group-flush">
-            <ListGroupItem>like: {example_articles[i].like_count} | view: {example_articles[i].view_count}</ListGroupItem>
-            <ListGroupItem>From: {example_articles[i].school_from} | To: {example_articles[i].school_to}</ListGroupItem>
-            <ListGroupItem>Major: {example_articles[i].major}</ListGroupItem>
-          </ListGroup>
-          <Card.Body>
-            <Card.Link href="#">Enter</Card.Link>
-            <Card.Link href="#">Report</Card.Link>
-          </Card.Body>
-        </Card>
+    const config = {
+      headers: { Authorization: `Bearer ${this.props.authState.accessToken.accessToken}` }
+    };
+    axios.get(url, config)
+      .then(
+        function (response) {
+          this.setState({
+            preRenderList: response.data
+          })
+        }.bind(this)
       )
+      .catch(function (error) {
+        console.log(error);
+        //Perform action based on error
+      });
+
+    var mappingList = []
+    var i = 0
+    var preRenderList = []
+    //Generate mapping list for later article card mapping
+    while (i < preRenderList.length) {
+      var innerList = []
+      for (var j = 0; j < 3; j++) {
+        if (i+j < preRenderList.length) {
+          innerList.push(preRenderList[i+j])
+        }
+      }
+      mappingList.push(innerList)
+      i += 3
     }
+    var tempList = (
+      <div>
+        {
+          mappingList.map( function(innerList, rowNum) {
+            return (
+              <Row key={rowNum}>
+                {
+                  innerList.map( function(article, colNum) {
+                    return (
+                      <Col key={colNum}>
+                        <Card className="storyCard">
+                          <Card.Body>
+                            <Card.Title>{article.article_title} ({article.article_id})</Card.Title>
+                            <Card.Text>
+                              {article.article_content}
+                            </Card.Text>
+                          </Card.Body>
+                          <ListGroup className="list-group-flush">
+                            <ListGroupItem>like: {article.like_count} | view: {article.view_count}</ListGroupItem>
+                            <ListGroupItem>From: {article.school_from.name} | To: {article.school_to.name}</ListGroupItem>
+                            <ListGroupItem>Major: {article.major.name}</ListGroupItem>
+                          </ListGroup>
+                          <Card.Body>
+                            <Card.Link href="#">Enter</Card.Link>
+                            <Card.Link href="#">Report</Card.Link>
+                          </Card.Body>
+                        </Card>
+                      </Col>
+                    )
+                  })
+                }
+              </Row>
+            )
+          })
+        }
+      </div>
+    )
     this.setState({
       renderList: tempList
     })
-  }
-
-  componentDidMount() {
-    this.updateRenderList(3);
   }
 
 
@@ -129,9 +189,9 @@ class StoryList extends React.Component {
             </Dropdown.Toggle>
 
             <Dropdown.Menu>
-              <Dropdown.Item onClick={this.updateRenderList} id="1">display 1,2</Dropdown.Item>
-              <Dropdown.Item onClick={this.updateRenderList} id="2">display 2,3</Dropdown.Item>
-              <Dropdown.Item onClick={this.updateRenderList} id="3">display all</Dropdown.Item>
+              <Dropdown.Item onClick={this.updateRenderList} id="1">user_id=1</Dropdown.Item>
+              <Dropdown.Item onClick={this.updateRenderList} id="2">user_id=3</Dropdown.Item>
+              <Dropdown.Item onClick={this.updateRenderList} id="all">display all</Dropdown.Item>
             </Dropdown.Menu>
           </Dropdown>
         </div>
@@ -141,6 +201,4 @@ class StoryList extends React.Component {
       </div>
     );
   }
-}
-
-export default StoryList;
+})

--- a/src/pages/story/StoryList.js
+++ b/src/pages/story/StoryList.js
@@ -104,11 +104,63 @@ export default withOktaAuth( class StoryList extends React.Component {
     const config = {
       headers: { Authorization: `Bearer ${this.props.authState.accessToken.accessToken}` }
     };
+    var preRenderList = []
     axios.get(url, config)
       .then(
         function (response) {
+          preRenderList = response.data
+          var mappingList = []
+          var i = 0
+          //Generate mapping list for later article card mapping
+          while (i < preRenderList.length) {
+            var innerList = []
+            for (var j = 0; j < 3; j++) {
+              if (i+j < preRenderList.length) {
+                innerList.push(preRenderList[i+j])
+              }
+            }
+            mappingList.push(innerList)
+            i += 3
+          }
+          var tempList = (
+            <div>
+              {
+                mappingList.map( function(innerList, rowNum) {
+                  return (
+                    <Row key={rowNum}>
+                      {
+                        innerList.map( function(article, colNum) {
+                          return (
+                            <Col key={colNum}>
+                              <Card className="storyCard">
+                                <Card.Body>
+                                  <Card.Title>{article.article_title} ({article.article_id})</Card.Title>
+                                  <Card.Text>
+                                    {article.article_content}
+                                  </Card.Text>
+                                </Card.Body>
+                                <ListGroup className="list-group-flush">
+                                  <ListGroupItem>like: {article.like_count} | view: {article.view_count}</ListGroupItem>
+                                  <ListGroupItem>From: {article.school_from.name} | To: {article.school_to.name}</ListGroupItem>
+                                  <ListGroupItem>Major: {article.major.name}</ListGroupItem>
+                                </ListGroup>
+                                <Card.Body>
+                                  <Card.Link href="#">Enter</Card.Link>
+                                  <Card.Link href="#">Report</Card.Link>
+                                </Card.Body>
+                              </Card>
+                            </Col>
+                          )
+                        })
+                      }
+                    </Row>
+                  )
+                })
+              }
+            </div>
+          )
           this.setState({
-            preRenderList: response.data
+            renderList: tempList
           })
         }.bind(this)
       )
@@ -116,61 +168,6 @@ export default withOktaAuth( class StoryList extends React.Component {
         console.log(error);
         //Perform action based on error
       });
-
-    var mappingList = []
-    var i = 0
-    var preRenderList = []
-    //Generate mapping list for later article card mapping
-    while (i < preRenderList.length) {
-      var innerList = []
-      for (var j = 0; j < 3; j++) {
-        if (i+j < preRenderList.length) {
-          innerList.push(preRenderList[i+j])
-        }
-      }
-      mappingList.push(innerList)
-      i += 3
-    }
-    var tempList = (
-      <div>
-        {
-          mappingList.map( function(innerList, rowNum) {
-            return (
-              <Row key={rowNum}>
-                {
-                  innerList.map( function(article, colNum) {
-                    return (
-                      <Col key={colNum}>
-                        <Card className="storyCard">
-                          <Card.Body>
-                            <Card.Title>{article.article_title} ({article.article_id})</Card.Title>
-                            <Card.Text>
-                              {article.article_content}
-                            </Card.Text>
-                          </Card.Body>
-                          <ListGroup className="list-group-flush">
-                            <ListGroupItem>like: {article.like_count} | view: {article.view_count}</ListGroupItem>
-                            <ListGroupItem>From: {article.school_from.name} | To: {article.school_to.name}</ListGroupItem>
-                            <ListGroupItem>Major: {article.major.name}</ListGroupItem>
-                          </ListGroup>
-                          <Card.Body>
-                            <Card.Link href="#">Enter</Card.Link>
-                            <Card.Link href="#">Report</Card.Link>
-                          </Card.Body>
-                        </Card>
-                      </Col>
-                    )
-                  })
-                }
-              </Row>
-            )
-          })
-        }
-      </div>
-    )
-    this.setState({
-      renderList: tempList
-    })
   }
 
 


### PR DESCRIPTION
## Changes
- [x] Add a get hook for getting stories (by all or by different users, use the button to test it out), now the List page will display the stories we have in DB

## Note
- This PR closes #27 
- You can actually choose not to deploy this frontend, but only run flask on you localhost:5000, and with mySQL settled. Visiting https://hopeful-raman-4e105b.netlify.app/ can link to your local DB directly since the hook connects to 127.0.0.1:5000

## How Has This Been Tested?
- Tested locally, with api server at version [e0fca6](https://github.com/FHDA/API_deployment/commit/e0fca6238606dece2e011ba2376b5c1be6d16a53) and DB set up using `FHDA/api_deployment/db_setupsetup_sql_db.sql`

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules